### PR TITLE
Add display name field to signup form

### DIFF
--- a/lib/slouch/accounts/user.ex
+++ b/lib/slouch/accounts/user.ex
@@ -42,6 +42,7 @@ defmodule Slouch.Accounts.User do
       password :password do
         identity_field :email
         hashed_password_field :hashed_password
+        register_action_accept [:display_name]
 
         resettable do
           sender Slouch.Accounts.User.Senders.SendPasswordResetEmail

--- a/lib/slouch_web/auth_overrides.ex
+++ b/lib/slouch_web/auth_overrides.ex
@@ -1,20 +1,7 @@
 defmodule SlouchWeb.AuthOverrides do
   use AshAuthentication.Phoenix.Overrides
 
-  # configure your UI overrides here
-
-  # First argument to `override` is the component name you are overriding.
-  # The body contains any number of configurations you wish to override
-  # Below are some examples
-
-  # For a complete reference, see https://hexdocs.pm/ash_authentication_phoenix/ui-overrides.html
-
-  # override AshAuthentication.Phoenix.Components.Banner do
-  #   set :image_url, "https://media.giphy.com/media/g7GKcSzwQfugw/giphy.gif"
-  #   set :text_class, "bg-red-500"
-  # end
-
-  # override AshAuthentication.Phoenix.Components.SignIn do
-  #  set :show_banner, false
-  # end
+  override AshAuthentication.Phoenix.Components.Password do
+    set :register_extra_component, SlouchWeb.Components.RegisterExtra
+  end
 end

--- a/lib/slouch_web/components/register_extra.ex
+++ b/lib/slouch_web/components/register_extra.ex
@@ -1,0 +1,19 @@
+defmodule SlouchWeb.Components.RegisterExtra do
+  use Phoenix.Component
+  import Phoenix.HTML.Form, only: [input_id: 2]
+  import PhoenixHTMLHelpers.Form
+
+  def render(assigns) do
+    ~H"""
+    <div class="mt-2 mb-2">
+      <label class="block text-sm font-medium text-base-content mb-1" for={input_id(@form, :display_name)}>
+        Display name
+      </label>
+      {text_input(@form, :display_name,
+        class: "input w-full",
+        placeholder: "How others will see you"
+      )}
+    </div>
+    """
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,7 +9,8 @@ alice =
   |> Ash.Changeset.for_create(:register_with_password, %{
     email: "alice@example.com",
     password: "password123456",
-    password_confirmation: "password123456"
+    password_confirmation: "password123456",
+    display_name: "Alice"
   })
   |> Ash.create!(authorize?: false)
 
@@ -18,7 +19,8 @@ bob =
   |> Ash.Changeset.for_create(:register_with_password, %{
     email: "bob@example.com",
     password: "password123456",
-    password_confirmation: "password123456"
+    password_confirmation: "password123456",
+    display_name: "Bob"
   })
   |> Ash.create!(authorize?: false)
 
@@ -30,9 +32,6 @@ for user <- [alice, bob] do
   |> Ecto.Changeset.change(%{confirmed_at: now})
   |> Slouch.Repo.update!()
 end
-
-alice |> Ecto.Changeset.change(%{display_name: "Alice"}) |> Slouch.Repo.update!()
-bob |> Ecto.Changeset.change(%{display_name: "Bob"}) |> Slouch.Repo.update!()
 
 IO.puts("Created users: alice@example.com, bob@example.com (password: password123456)")
 


### PR DESCRIPTION
## Summary
- Adds a display name text input to the registration form — closes #4
- Uses AshAuthentication's `register_action_accept` to allow display_name during password registration
- Implements a custom `RegisterExtra` component wired via auth overrides
- Updates seeds to pass display_name directly during registration

## Test plan
- [ ] Register a new account and verify display name field appears
- [ ] Verify display name is saved and shown in the chat UI
- [ ] Verify registration still works without providing a display name (optional field)